### PR TITLE
Added proper bounds checking for object handle

### DIFF
--- a/include/MtpDatabase.h
+++ b/include/MtpDatabase.h
@@ -30,6 +30,8 @@ class MtpDatabase {
 public:
     virtual ~MtpDatabase() {}
 
+    virtual bool                    isHandleValid(MtpObjectHandle handle) = 0;
+
     // called to add a path to include in the database.
     virtual void                    addStoragePath(const MtpString& path,
                                                    const MtpString& displayName,

--- a/include/SwitchMtpDatabase.h
+++ b/include/SwitchMtpDatabase.h
@@ -57,7 +57,7 @@ private:
         std::string display_name;
         std::string path;
         std::time_t last_modified;
-        bool scanned;
+        bool scanned = false;
     };
 
     MtpServer* local_server;
@@ -107,7 +107,6 @@ private:
                 entry.path = p.string();
                 entry.object_format = MTP_FORMAT_ASSOCIATION;
                 entry.object_size = 0;
-                entry.scanned = false;
 
                 struct stat result;
                 stat(p.string().c_str(), &result);
@@ -220,6 +219,10 @@ public:
     virtual ~SwitchMtpDatabase() {
     }
 
+    virtual bool isHandleValid(MtpObjectHandle handle) {
+        return handle > 0 && handle < counter;
+    }
+
     virtual void addStoragePath(const MtpString& path,
                                 const MtpString& displayName,
                                 MtpStorageID storage,
@@ -312,7 +315,7 @@ public:
             parent = 0;
         
         // Scan unscanned directories
-        else if (!db.at(parent).scanned)
+        else if (isHandleValid(parent) && !db.at(parent).scanned)
             parse_directory (db.at(parent).path, parent, storageID);
 
         try

--- a/include/SwitchMtpDatabase.h
+++ b/include/SwitchMtpDatabase.h
@@ -950,8 +950,8 @@ public:
             return nullptr;
 
         return getObjectList(db.at(handle).storage_id,
-                             handle,
-                             db.at(handle).object_format);
+                             db.at(handle).object_format,
+                             handle);
     }
 
     virtual MtpResponseCode setObjectReferences(

--- a/source/MtpServer.cpp
+++ b/source/MtpServer.cpp
@@ -600,7 +600,10 @@ MtpResponseCode MtpServer::doGetObjectReferences() {
         return MTP_RESPONSE_INVALID_OBJECT_HANDLE;
     MtpObjectHandle handle = mRequest.getParameter(1);
 
-    // FIXME - check for invalid object handle
+    if (!mDatabase->isHandleValid(handle)) {
+        return MTP_RESPONSE_INVALID_OBJECT_HANDLE;
+    }
+
     MtpObjectHandleList* handles = mDatabase->getObjectReferences(handle);
     if (handles) {
         mData.putAUInt32(handles);


### PR DESCRIPTION
Windows was requesting information on an invalid object handle that wasn't being checked causing invalid memory access. This fixes it for that instance. Fix should be easily applied to other instances but I would like a better understanding of how MTP works before putting it everywhere.